### PR TITLE
Fix broken asset URLs

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,6 @@
   },
   "dependencies": {
     "hexo": "^4.2.1",
-    "hexo-asset-image": "^1.0.0",
     "hexo-cli": "^3.1.0",
     "hexo-deployer-git": "^2.1.0",
     "hexo-generator-archive": "^1.0.0",


### PR DESCRIPTION
这个 PR 移除了一个无用的依赖 hexo-asset-image．这个依赖会导致生成的图片链接完全失效，以最近的一次 CI 构建为例：

```text
update link as:-->/blog/.io//image-20220916192744500.png
update link as:-->/blog/.io//image-20220916193049912.png
update link as:-->/blog/.io//image-20220916192744500.png
update link as:-->/blog/.io//image-20220916193049912.png
update link as:-->/blog/.io//gdb-inner.drawio.svg
update link as:-->/blog/.io//ui-debugadapter-debugger.drawio.svg
update link as:-->/blog/.io//cortex-debug-thread-info.png
update link as:-->/blog/.io//difference-with-cortex-debug.drawio.svg
update link as:-->/blog/.io//gdb-inner.drawio.svg
update link as:-->/blog/.io//ui-debugadapter-debugger.drawio.svg
update link as:-->/blog/.io//cortex-debug-thread-info.png
update link as:-->/blog/.io//difference-with-cortex-debug.drawio.svg
update link as:-->/blog/.io//image.png
```

你会发现这里莫名奇妙多了一个 `/.io//` 路径，就导致图片定位到了一个不存在的文件夹，具体日志见[此链接](https://github.com/rcore-os/blog/actions/runs/15997997579/job/45125773746#step:4:394)．

我推测应该是 [hexo-asset-image](https://github.com/xcodebuild/hexo-asset-image) 本身的代码有问题．这个 repo 早在 6 年前就已经被 archive 了．

我本地测试了去掉此依赖后对构建的影响，除了图片链接被纠正以外没有其它副作用．