### PR TITLE
ci: upgrade Node.js to v20 and GitHub Actions to v4

### DIFF
--- a/.github/workflows/auto-deploy.yml
+++ b/.github/workflows/auto-deploy.yml
@@ -14,11 +14,11 @@ jobs:
     runs-on: ubuntu-22.04
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v4
         with:
-          node-version: 16
+          node-version: 20
 
       - name: build
         run: |


### PR DESCRIPTION
### Description
Node.js 16 has reached its End of Life (EOL). This PR upgrades the CI environment to Node.js 20 (LTS) and updates the GitHub Actions plugins to v4 to ensure better security, performance, and to resolve potential deprecation warnings.

### Changes
- Updated `.github/workflows/auto-deploy.yml`:
  - Changed `node-version` from `16` to `20`.
  - Upgraded `actions/checkout` from `v3` to `v4`.
  - Upgraded `actions/setup-node` from `v3` to `v4`.

### Verification
- [x] Local build verified: Ran `npm install` and `hexo generate` successfully on a modern Node.js environment.
- [x] Generated 2000+ static files without any errors.

This change ensures the blog's deployment pipeline remains stable and up-to-date with current industry standards.